### PR TITLE
test(stripe): console log stripe webhook variables

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,13 +1,9 @@
 import { Controller, Get } from '@nestjs/common'
 import { AppService } from './app.service'
-import { MailerService } from '@app/mailer'
 
 @Controller()
 export class AppController {
-  constructor(
-    private readonly appService: AppService,
-    private readonly mailerService: MailerService,
-  ) {}
+  constructor(private readonly appService: AppService) {}
 
   @Get()
   getHello(): string {

--- a/src/stripe/stripe.controller.ts
+++ b/src/stripe/stripe.controller.ts
@@ -12,16 +12,24 @@ export class StripeController {
 
   @Post()
   async handleStripeWebhook(@Req() req, @Res() res) {
+    console.log({ reqBody: req.body })
+
     const stripe = new Stripe(
       this.configService.get<string>('STRIPE_SECRET_KEY'),
       {
         apiVersion: '2024-12-18.acacia',
       },
     )
+
+    console.log({ stripe })
     const endpointSecret = this.configService.get<string>(
       'STRIPE_WEBHOOK_SECRET',
     )
+    console.log({ endpointSecret })
+
     const signature = req.headers['stripe-signature']
+
+    console.log({ signature })
 
     let event
     try {
@@ -30,6 +38,8 @@ export class StripeController {
         signature,
         endpointSecret,
       )
+
+      console.log({ stripe })
     } catch (err) {
       console.error('Webhook signature verification failed:', err.message)
       return res.status(400).send(`Webhook Error: ${err.message}`)


### PR DESCRIPTION
Debug stripe webhook failure
0|joy-it-backend  | Webhook signature verification failed: Webhook payload must be provided as a string or a Buffer (https://nodejs.org/api/buffer.html) instance representing the _raw_ request body.Payload was provided as a parsed JavaScript object instead.